### PR TITLE
Update SendEmail.java

### DIFF
--- a/EmailModuleWithTemplates_src/javasource/emailtemplate/actions/SendEmail.java
+++ b/EmailModuleWithTemplates_src/javasource/emailtemplate/actions/SendEmail.java
@@ -101,7 +101,7 @@ public class SendEmail extends CustomJavaAction<Boolean>
 		config.setUseSSLSMTP(this.UseSSL);
 		config.setUseTLSSMTP(this.UseTLS);
 
-		String separator = (String) Core.getConfiguration().getConstantValue("EmailTemplate.EmailAddressSeparator");
+		String separator = (String) emailtemplate.proxies.constants.Constants.getEmailAddressSeparator();
 		if (separator == null)
 			separator = ",";
 


### PR DESCRIPTION
Hi Roeland,

We have customized this module and renamed to prevent overwriting from the appstore. In that case it should have better to use the constant value in this way. It would have lead to a syntax error instead of a runtime error.

Chris