### PR TITLE
Added data:base64 to pattern match to avoid decoding url references

### DIFF
--- a/src/EmailModuleWithTemplates/javasource/emailtemplate/mail/Sender.java
+++ b/src/EmailModuleWithTemplates/javasource/emailtemplate/mail/Sender.java
@@ -44,7 +44,7 @@ public class Sender
 	private final static String FILE_DOCUMENT = "System.FileDocument";
 	
 	private final IContext context;
-	private static final Pattern imgElement  = Pattern.compile( "<img[^>]+src\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>" );
+	private static final Pattern imgElement  = Pattern.compile( "<img[^>]+src\\s*=\\s*['\"]((data:base64)[^'\"]+)['\"][^>]*>" );
 	
 	public Sender(IContext _context) 
 	{


### PR DESCRIPTION
Parsing a url based img src caused a java.lang.ArrayIndexOutOfBoundsException at emailtemplate.mail.Sender.send(Sender.java:95).